### PR TITLE
refactor/#22: 메일 푸쉬 알림 분리

### DIFF
--- a/src/main/java/com/verby/indp/domain/common/event/mail/MailSendEvent.java
+++ b/src/main/java/com/verby/indp/domain/common/event/mail/MailSendEvent.java
@@ -1,0 +1,8 @@
+package com.verby.indp.domain.common.event.mail;
+
+import com.verby.indp.domain.common.notification.mail.Mail;
+
+public record MailSendEvent(
+    Mail mail
+) {
+}

--- a/src/main/java/com/verby/indp/domain/common/event/mail/MailSendListener.java
+++ b/src/main/java/com/verby/indp/domain/common/event/mail/MailSendListener.java
@@ -1,0 +1,21 @@
+package com.verby.indp.domain.common.event.mail;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+import com.verby.indp.domain.common.notification.mail.MailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Service
+@RequiredArgsConstructor
+public class MailSendListener {
+
+    private final MailService mailService;
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void handleMailSendEvent(MailSendEvent event) {
+        mailService.sendMail(event.mail());
+    }
+
+}

--- a/src/main/java/com/verby/indp/domain/contact/service/ContactService.java
+++ b/src/main/java/com/verby/indp/domain/contact/service/ContactService.java
@@ -1,5 +1,6 @@
 package com.verby.indp.domain.contact.service;
 
+import com.verby.indp.domain.common.event.mail.MailSendEvent;
 import com.verby.indp.domain.common.notification.mail.Mail;
 import com.verby.indp.domain.common.notification.mail.MailService;
 import com.verby.indp.domain.contact.Contact;
@@ -7,6 +8,7 @@ import com.verby.indp.domain.contact.dto.request.RegisterContactRequest;
 import com.verby.indp.domain.contact.repository.ContactRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,7 +21,7 @@ public class ContactService {
     private String to;
 
     private final ContactRepository contactRepository;
-    private final MailService mailService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
     public long registerContact(RegisterContactRequest request) {
@@ -30,7 +32,7 @@ public class ContactService {
             "문의 내용: " + request.content() + "\n" +
             "문의자 성함: " + request.userName() + "\n" +
             "문의자 연락처: " + request.phoneNumber() + "\n");
-        mailService.sendMail(mail);
+        applicationEventPublisher.publishEvent(new MailSendEvent(mail));
 
         return persistContact.getContactId();
     }

--- a/src/main/java/com/verby/indp/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/verby/indp/domain/recommendation/service/RecommendationService.java
@@ -1,5 +1,6 @@
 package com.verby.indp.domain.recommendation.service;
 
+import com.verby.indp.domain.common.event.mail.MailSendEvent;
 import com.verby.indp.domain.common.notification.mail.Mail;
 import com.verby.indp.domain.common.notification.mail.MailService;
 import com.verby.indp.domain.recommendation.Recommendation;
@@ -9,6 +10,7 @@ import com.verby.indp.domain.store.Store;
 import com.verby.indp.domain.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,7 +24,7 @@ public class RecommendationService {
 
     private final RecommendationRepository recommendationRepository;
     private final StoreRepository storeRepository;
-    private final MailService mailService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
     public long registerRecommendation(RegisterRecommendationRequest request) {
@@ -37,7 +39,7 @@ public class RecommendationService {
                 "추천인 연락처: " + request.phoneNumber() + "\n" +
                 "매장 이름: " + store.getName() + "\n" +
                 "매장 주소: " + store.getAddress() + "\n");
-        mailService.sendMail(mail);
+        applicationEventPublisher.publishEvent(new MailSendEvent(mail));
 
         return persistRecommendation.getRecommendationId();
     }

--- a/src/main/java/com/verby/indp/global/config/AsyncConfig.java
+++ b/src/main/java/com/verby/indp/global/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.verby.indp.global.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "asyncEmailSendExecutor")
+    public Executor asyncEmailSendExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("Executor-");
+        return executor;
+    }
+
+}

--- a/src/main/java/com/verby/indp/global/mail/SpringMailService.java
+++ b/src/main/java/com/verby/indp/global/mail/SpringMailService.java
@@ -1,19 +1,28 @@
 package com.verby.indp.global.mail;
 
-import com.verby.indp.domain.common.notification.mail.MailService;
 import com.verby.indp.domain.common.notification.mail.Mail;
+import com.verby.indp.domain.common.notification.mail.MailService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailAuthenticationException;
+import org.springframework.mail.MailParseException;
+import org.springframework.mail.MailSendException;
 import org.springframework.mail.MailSender;
 import org.springframework.mail.SimpleMailMessage;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SpringMailService implements MailService {
 
+    private static final int MAX_RETRY_COUNT = 5;
+
     private final MailSender mailSender;
 
     @Override
+    @Async("asyncEmailSendExecutor")
     public void sendMail(Mail mail) {
         SimpleMailMessage message = new SimpleMailMessage();
 
@@ -21,6 +30,22 @@ public class SpringMailService implements MailService {
         message.setSubject(mail.subject());
         message.setText(mail.text());
 
-        mailSender.send(message);
+        send(message);
+    }
+
+    private void send(SimpleMailMessage message) {
+        int count = 0;
+        for (; count < MAX_RETRY_COUNT; count++) {
+            try {
+                mailSender.send(message);
+                return;
+            } catch (MailParseException | MailAuthenticationException exception) {
+                log.error("메일 전송을 실패하였습니다.", exception);
+                return;
+            } catch (MailSendException exception) {
+                log.warn("메일 전송을 실패하였습니다. 재시도합니다. 재시도 횟수: {}", count, exception);
+            }
+        }
+        log.error("메일 전송에 실패하였습니다. 재시도 횟수: {}", count);
     }
 }

--- a/src/test/java/com/verby/indp/domain/common/notification/mail/MailServiceTest.java
+++ b/src/test/java/com/verby/indp/domain/common/notification/mail/MailServiceTest.java
@@ -1,6 +1,7 @@
 package com.verby.indp.domain.common.notification.mail;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.MailSendException;
 import org.springframework.mail.MailSender;
 import org.springframework.mail.SimpleMailMessage;
 
@@ -39,6 +41,22 @@ class MailServiceTest {
 
             // then
             verify(mailSender, times(1)).send(any(SimpleMailMessage.class));
+        }
+
+        @Test
+        @DisplayName("성공: 메일을 전송 실패시 재시도한다.")
+        void reSendMailWhenSendFail() {
+            // given
+            Mail mail = new Mail("to", "subject", "text");
+            int MAX_RETRY_COUNT = 5;
+
+            doThrow(new MailSendException("메일 전송 실패")).when(mailSender).send(any(SimpleMailMessage.class));
+
+            // when
+            mailService.sendMail(mail);
+
+            // then
+            verify(mailSender, times(MAX_RETRY_COUNT)).send(any(SimpleMailMessage.class));
         }
     }
 

--- a/src/test/java/com/verby/indp/domain/contact/service/ContactServiceTest.java
+++ b/src/test/java/com/verby/indp/domain/contact/service/ContactServiceTest.java
@@ -6,8 +6,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.verby.indp.domain.common.notification.mail.Mail;
-import com.verby.indp.domain.common.notification.mail.MailService;
+import com.verby.indp.domain.common.event.mail.MailSendEvent;
 import com.verby.indp.domain.contact.Contact;
 import com.verby.indp.domain.contact.dto.request.RegisterContactRequest;
 import com.verby.indp.domain.contact.repository.ContactRepository;
@@ -18,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class ContactServiceTest {
@@ -29,7 +29,7 @@ class ContactServiceTest {
     private ContactRepository contactRepository;
 
     @Mock
-    private MailService mailService;
+    private ApplicationEventPublisher applicationEventPublisher;
 
     @Nested
     @DisplayName("registerContact 메소드 호출 시")
@@ -51,7 +51,7 @@ class ContactServiceTest {
 
             // then
             verify(contactRepository, times(1)).save(any(Contact.class));
-            verify(mailService, times(1)).sendMail(any(Mail.class));
+            verify(applicationEventPublisher, times(1)).publishEvent(any(MailSendEvent.class));
         }
 
     }

--- a/src/test/java/com/verby/indp/domain/recommendation/service/RecommendationServiceTest.java
+++ b/src/test/java/com/verby/indp/domain/recommendation/service/RecommendationServiceTest.java
@@ -10,8 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.verby.indp.domain.common.notification.mail.Mail;
-import com.verby.indp.domain.common.notification.mail.MailService;
+import com.verby.indp.domain.common.event.mail.MailSendEvent;
 import com.verby.indp.domain.recommendation.Recommendation;
 import com.verby.indp.domain.recommendation.dto.request.RegisterRecommendationRequest;
 import com.verby.indp.domain.recommendation.repository.RecommendationRepository;
@@ -25,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class RecommendationServiceTest {
@@ -39,7 +39,7 @@ class RecommendationServiceTest {
     private StoreRepository storeRepository;
 
     @Mock
-    private MailService mailService;
+    private ApplicationEventPublisher applicationEventPublisher;
 
     @Nested
     @DisplayName("registerRecommendation 메소드 실행 시")
@@ -65,7 +65,7 @@ class RecommendationServiceTest {
 
             // then
             verify(recommendationRepository, times(1)).save(any(Recommendation.class));
-            verify(mailService, times(1)).sendMail(any(Mail.class));
+            verify(applicationEventPublisher, times(1)).publishEvent(any(MailSendEvent.class));
         }
 
         @Test


### PR DESCRIPTION
### 📢 개요
- 기존의 메일 푸쉬 알림은 한 트랜잭션 내에서 메일 전송 로직이 수행됩니다. 이 경우 제 3자 서비스(메일 전송)에 장애가 발생할 경우 커넥션이 물려있어 시스템 전체의 장애로 이어질 수 있습니다. 해당 문제를 해결하기 위해 `@TransactionalEventListener` 과 `@Async` 를 사용하여 트랜잭션 외부로 분리하면서 메일 전송이 비동기적으로 처리되도록 리팩토링 하였습니다.
- 메일 전송에 실패할 경우를 대비하여 재시도 메카니즘을 구현하였습니다.

### 📝 작업 내용
- `MailSendEvent`, `MailSendListener(@TransactionalEventListener(phase = AFTER_COMMIT))` 생성
- `AsyncConfig` 생성
- `EventPublisher` 를 사용하여 메일 전송 메서드 호출하도록 수정
- `@Async` 적용하여 메일 전송이 비동기적으로 동작하도록 수정
- 메일 전송에 실패할 경우 반복문을 통해 재시도 및 로깅 설정 

### 💡 관련 이슈
- close #22 
