### PR TITLE
fix: imageUrl 길이 제한 변경

### DIFF
--- a/src/main/java/com/verby/indp/domain/store/StoreImage.java
+++ b/src/main/java/com/verby/indp/domain/store/StoreImage.java
@@ -27,7 +27,7 @@ public class StoreImage {
     private Store store;
 
     @Getter
-    @Column(name = "image_url")
+    @Column(name = "image_url", length = 10000)
     private String imageUrl;
 
     public StoreImage(Store store, String imageUrl) {


### PR DESCRIPTION
### 📢 개요
- imageUrl 길이 제한 변경

### 📝 작업 내용
- imageUrl 최대 길이를 10,000자로 수정 (s3 url 최대 길이: 8,192byte)

### 💡 관련 이슈
- close #38 
