### PR TITLE
fix: ExceptionHandler 예외 타입 수정

### DIFF
--- a/src/main/java/com/verby/indp/domain/common/exception/ControllerAdvice.java
+++ b/src/main/java/com/verby/indp/domain/common/exception/ControllerAdvice.java
@@ -16,7 +16,7 @@ public class ControllerAdvice {
         return ResponseEntity.status(exception.getStatusCode()).body(new ErrorResponse(exception.getMessage()));
     }
 
-    @ExceptionHandler(Exception.class)
+    @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ErrorResponse> handleException(RuntimeException exception) {
         String exName = exception.getClass().getSimpleName();
         String exMessage = exception.getMessage();


### PR DESCRIPTION
### 📢 개요
- `@ExceptionHandler` 의 예외 타입과 메서드 인자의 타입 불일치로 인해 IllegalStateException 발생

### 📝 작업 내용
- `@ExceptionHandler` 예외 타입을 메서드 인자 타입인 RuntimeException 으로 수정

### 💡 관련 이슈
- close #57 
